### PR TITLE
Change private constructor to public

### DIFF
--- a/src/banking/primitive/core/Checking.java
+++ b/src/banking/primitive/core/Checking.java
@@ -9,10 +9,6 @@ public class Checking extends Account {
 		super(name);
 	}
 
-    public static Checking createChecking(String name) {
-        return new Checking(name);
-    }
-
 	public Checking(String name, float balance) {
 		super(name, balance);
 	}

--- a/src/banking/primitive/core/Checking.java
+++ b/src/banking/primitive/core/Checking.java
@@ -5,7 +5,7 @@ public class Checking extends Account {
 	private static final long serialVersionUID = 11L;
 	private int numWithdraws = 0;
 	
-	private Checking(String name) {
+	public Checking(String name) {
 		super(name);
 	}
 


### PR DESCRIPTION
Updated the, for some reason, `private` constructor to be `public`. Addresses issue #18 
