### PR TITLE
Corrected faulty business logic #14

### DIFF
--- a/src/banking/primitive/core/Savings.java
+++ b/src/banking/primitive/core/Savings.java
@@ -36,7 +36,7 @@ public class Savings extends Account {
 			if (numWithdraws > 3)
 				balance = balance - 1.0f;
 			// KG BVA: should be < 0
-			if (balance <= 0.0f) {
+			if (balance < 0.0f) {
 				setState(State.OVERDRAWN);
 			}
 			return true;

--- a/src/banking/primitive/core/Savings.java
+++ b/src/banking/primitive/core/Savings.java
@@ -30,7 +30,7 @@ public class Savings extends Account {
 	 * An account whose balance dips below 0 is in an OVERDRAWN state
 	 */
 	public boolean withdraw(float amount) {
-		if (getState() == State.OPEN && amount > 0.0f) {
+		if (getState() == State.OPEN && amount >= 0.0f) {
 			balance = balance - amount;
 			numWithdraws++;
 			if (numWithdraws > 3)


### PR DESCRIPTION
Addresses #14 

Per requirements, accounts are not overdrawn until below 0.0f

Corrected defect which caused accounts to be overdrawn at 0.0f.
