### PR TITLE
Corrected method overriding super's implementation

### DIFF
--- a/src/banking/primitive/core/Checking.java
+++ b/src/banking/primitive/core/Checking.java
@@ -51,7 +51,4 @@ public class Checking extends Account {
 
 	public String getType() { return "Checking"; }
 	
-	public String toString() {
-		return "Checking: " + getName() + ": " + getBalance();
-	}
 }


### PR DESCRIPTION
Addresses #10 

Parent class's toString() provides more information than child, so removed child's toString().
