### PR TITLE
Removed redundant child toString()

### DIFF
--- a/src/banking/primitive/core/Savings.java
+++ b/src/banking/primitive/core/Savings.java
@@ -46,7 +46,4 @@ public class Savings extends Account {
 	
 	public String getType() { return "Savings"; }
 
-	public String toString() {
-		return "Savings: " + getName() + ": " + getBalance();
-	}
 }


### PR DESCRIPTION
Addresses #12 

Fixed Savings.java toString() overriding parent and giving less information by removing method.
